### PR TITLE
Refactor FragmentDialogCalling class

### DIFF
--- a/app/src/main/java/com/dev/ipati/fragmentdialog/FragmentDialog.kt
+++ b/app/src/main/java/com/dev/ipati/fragmentdialog/FragmentDialog.kt
@@ -109,7 +109,7 @@ class FragmentDialog : DialogFragment() {
             return this
         }
 
-        fun builder(): FragmentDialog {
+        fun build(): FragmentDialog {
             return FragmentDialog.newInstance(headerDialog!!, descriptionDialog!!)
         }
     }

--- a/app/src/main/java/com/dev/ipati/fragmentdialog/FragmentDialogCalling.kt
+++ b/app/src/main/java/com/dev/ipati/fragmentdialog/FragmentDialogCalling.kt
@@ -1,6 +1,5 @@
 package com.dev.ipati.fragmentdialog
 
-import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.view.View
@@ -10,18 +9,19 @@ class FragmentDialogCalling : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        val fragmentDialog: FragmentDialog = FragmentDialog.Builder().headingDialog("HelloFragmentDialog")
-                .descriptionDialog("i'm Fragmnt Dialog").builder()
+        val fragmentDialog: FragmentDialog = FragmentDialog.Builder()
+            .headingDialog("HelloFragmentDialog")
+            .descriptionDialog("I'm Fragment Dialog")
+            .build()
 
         fragmentDialog.show(childFragmentManager, "")
     }
 
     companion object {
         fun newInstance(name: String): FragmentDialogCalling {
-            val fragmentcallingDialog: FragmentDialogCalling = FragmentDialogCalling()
-            val bundel: Bundle = Bundle()
-            bundel.putString("DialogCalling", name)
-            return fragmentcallingDialog
+            return FragmentDialogCalling().apply {
+                arguments = Bundle().apply { putString("DialogCalling", name) }
+            }
         }
     }
 }

--- a/app/src/main/java/com/dev/ipati/fragmentdialog/MainActivity.kt
+++ b/app/src/main/java/com/dev/ipati/fragmentdialog/MainActivity.kt
@@ -1,11 +1,8 @@
 package com.dev.ipati.fragmentdialog
 
 
-import android.app.Dialog
-import android.app.Fragment
 import android.support.v7.app.AppCompatActivity
 import android.os.Bundle
-import android.support.v7.app.AlertDialog
 import android.view.View
 import android.widget.Button
 import android.widget.Toast
@@ -34,7 +31,7 @@ class MainActivity : AppCompatActivity(), FragmentDialog.DialogOnClickListener {
 //                Msg =
 //            }
             val fragmentDialog: FragmentDialog = FragmentDialog.Builder().headingDialog("HeaderDialogFragment")
-                    .descriptionDialog("I'am Fragment Dialog Kotlin").builder()
+                    .descriptionDialog("I'am Fragment Dialog Kotlin").build()
             fragmentDialog.isCancelable = false
             fragmentDialog.show(supportFragmentManager, "fragmentDialog")
         })


### PR DESCRIPTION
## What happened 🤔
Refactor `FragmentDialogCalling`
- Typos
- Builder naming should be `build` when we finish creating builder not `builder`
- Bundle's argument is unused for some reason, So I put them to `FragmentCallingDialog's argument`


## Insight 👀
So many typos 🙀 