### PR TITLE
Improve fragment's communication

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,6 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
+      <module fileurl="file://$PROJECT_DIR$/DialogFragment.iml" filepath="$PROJECT_DIR$/DialogFragment.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/dialog-fragment.iml" filepath="$PROJECT_DIR$/.idea/dialog-fragment.iml" />
     </modules>

--- a/app/src/main/java/com/dev/ipati/fragmentdialog/FragmentDialog.kt
+++ b/app/src/main/java/com/dev/ipati/fragmentdialog/FragmentDialog.kt
@@ -2,6 +2,7 @@ package com.dev.ipati.fragmentdialog
 
 import android.os.Bundle
 import android.support.v4.app.DialogFragment
+import android.support.v4.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -11,8 +12,6 @@ class FragmentDialog : DialogFragment() {
 
     var header: String? = DEFAULT_DIALOG_HEADER
     var message: String? = DEFAULT_DIALOG_MESSAGE
-
-    var dialogClickListener: DialogOnClickListener? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -33,22 +32,16 @@ class FragmentDialog : DialogFragment() {
     }
 
     private fun initInstance() {
-        dialogClickListener = if (parentFragment != null) {
-            parentFragment as DialogOnClickListener
-        } else {
-            activity as DialogOnClickListener
-        }
-
         tvHeader.text = header
         tvDescription.text = message
 
         btSubmit.setOnClickListener { view ->
-            dialogClickListener?.onDialogPositiveClickListener(view)
+            delegate<DialogOnClickListener>()?.onDialogPositiveClickListener(view)
             dismiss()
         }
 
         btCancel?.setOnClickListener { view ->
-            dialogClickListener?.onDialogNegativeClickListener(view)
+            delegate<DialogOnClickListener>()?.onDialogNegativeClickListener(view)
             dismiss()
         }
     }
@@ -67,6 +60,13 @@ class FragmentDialog : DialogFragment() {
     private fun onRestoreInstanceState(bundle: Bundle?) {
         header = bundle?.getString(ARGS_HEADER)
         message = bundle?.getString(ARGS_MESSAGE)
+    }
+
+    private inline fun <reified T> Fragment.delegate(): T? = when {
+        targetFragment is T -> targetFragment as T
+        parentFragment is T -> parentFragment as T
+        activity is T -> activity as T
+        else -> null
     }
 
     interface DialogOnClickListener {


### PR DESCRIPTION
Use `inline function` with `reified` modifier for checking generic type, So that it can check if the `DialogClickListener` is implemented by `parentFragment`, or `targetFragment`, or `activity`

With this approach we don't have to keep the `DialogClickListener` as a variable which makes the code easier to understand and it is also possible to reuse function now. 